### PR TITLE
Drv update

### DIFF
--- a/drv/Makefile
+++ b/drv/Makefile
@@ -1,9 +1,9 @@
 .PHONY: check-env
 obj-m += iit-hpucore-dma.o
 all: check-env
-	make -C $(KDIR) M=$(PWD) ARCH=arm CROSS_COMPILE=arm-none-eabi- modules
+	make -C $(KDIR) M=$(PWD) modules
 clean: check-env
-	make -C $(KDIR) M=$(PWD) ARCH=arm CROSS_COMPILE=arm-none-eabi- clean
+	make -C $(KDIR) M=$(PWD) clean
 
 check-env:
 ifndef KDIR

--- a/drv/README.md
+++ b/drv/README.md
@@ -391,6 +391,6 @@ The DMA driver needs to be able to:
 - Enqueue new transfer requests while running
 - Support partial transfers (i.e. early-terminated transfers, providing residue information)
 
-EDL Zynq kernel (https://github.com/andreamerello/linux-zynq-stable) has been patched in order to accomplish to this requirements.
+EDL [Zynq7000](https://gitlab.iit.it/edl/linux-kernel-zynq7000) and [ZynqMP](https://gitlab.iit.it/edl/linux-kernel-zynqmp) kernels have been patched with a customized DMA Xilinx driver that satisfy to these requirements.
 
-Depending by [rx/tx]_[pn/ps] The HPU driver needs to allocate large portions of DMAable memory. Please make sure that CMA (Contiguous Memory Allocator) is enabled in kernel config (CONFIG_CMA=y) and that a reasonable amount of memory is reserved (e.g. append *CMA=32M* to your kernel arguments).
+*NOTE*: expecially on Zynq7000, a lot of coherent memory is used by the drv; depending by [rx/tx]_[pn/ps] The HPU driver needs to allocate large portions of DMAable memory. Please make sure that CMA (Contiguous Memory Allocator) is enabled in kernel config (CONFIG_CMA=y) and that a reasonable amount of memory is reserved (e.g. append *CMA=32M* to your kernel arguments).

--- a/drv/iit-hpucore-dma.c
+++ b/drv/iit-hpucore-dma.c
@@ -512,9 +512,15 @@ static inline void *dma_alloc_noncoherent(struct device *dev, size_t size,
 		dma_addr_t *dma_handle, enum dma_data_direction dir, gfp_t gfp)
 {
 	void *virt = kmalloc(size, GFP_KERNEL);
-	if (virt)
+	if (virt) {
 		*dma_handle = dma_map_single_attrs(dev, virt, size, dir,
 		       DMA_ATTR_NON_CONSISTENT | DMA_ATTR_WRITE_COMBINE);
+		if (dma_mapping_error(dev, *dma_handle))  {
+			kfree(virt);
+			return NULL;
+		}
+	}
+
 	return virt;
 }
 

--- a/drv/iit-hpucore-dma.c
+++ b/drv/iit-hpucore-dma.c
@@ -932,7 +932,7 @@ static ssize_t hpu_chardev_read(struct file *fp, char *buf, size_t length,
 #endif
 		return -EFAULT;
 
-	dev_dbg(&priv->pdev->dev, "----tot to read %d\n", length);
+	dev_dbg(&priv->pdev->dev, "----tot to read %zu\n", length);
 
 	mutex_lock(&priv->dma_rx_pool.mutex_lock);
 
@@ -1037,7 +1037,7 @@ static ssize_t hpu_chardev_read(struct file *fp, char *buf, size_t length,
 		buf_count = item->tail_index - item->head_index;
 		copy = min(length, buf_count);
 
-		dev_dbg(&priv->pdev->dev, "going to read %d bytes from offset %d\n",
+		dev_dbg(&priv->pdev->dev, "going to read %zu bytes from offset %d\n",
 			length, item->head_index);
 
 		ret = __copy_to_user(buf + read,
@@ -1081,7 +1081,7 @@ static ssize_t hpu_chardev_read(struct file *fp, char *buf, size_t length,
 		read += copy;
 		length -= copy;
 		BUG_ON(length < 0);
-		dev_dbg(&priv->pdev->dev, "read %d, rem %d\n", read, length);
+		dev_dbg(&priv->pdev->dev, "read %zu, rem %zu\n", read, length);
 
 		/* partially copied */
 		if (ret)
@@ -2449,7 +2449,7 @@ static int hpu_probe(struct platform_device *pdev)
 	hpu_register_chardev(priv);
 
 	if (hpu_debugfsdir) {
-		sprintf(buf, "hpu.%x", res->start);
+		sprintf(buf, "hpu.%pa", &res->start);
 		priv->debugfsdir = debugfs_create_dir(buf, hpu_debugfsdir);
 	}
 

--- a/drv/iit-hpucore-dma.c
+++ b/drv/iit-hpucore-dma.c
@@ -1109,6 +1109,14 @@ static int hpu_dma_init(struct hpu_priv *priv)
 		return -ENODEV;
 	}
 
+	/*
+	 * DMA RX channel is mandatory, while TX is not. We assume RX and TX
+	 * CHs are two CHs from the same DMA controller, so we just set the
+	 * mask as per the RX channel
+	 */
+	dma_set_mask_and_coherent(&priv->pdev->dev,
+				  dma_get_mask(priv->dma_rx_chan->device->dev));
+
 	priv->dma_tx_chan = dma_request_slave_channel(&priv->pdev->dev, "tx");
 
 	if (IS_ERR_OR_NULL(priv->dma_tx_chan)) {

--- a/drv/iit-hpucore-dma.c
+++ b/drv/iit-hpucore-dma.c
@@ -34,6 +34,7 @@
 #include <linux/dmapool.h>
 #include <linux/interrupt.h>
 #include <linux/stringify.h>
+#include <linux/version.h>
 
 /* max HPUs that can be handled */
 #define HPU_MINOR_COUNT 10
@@ -801,7 +802,11 @@ static ssize_t hpu_chardev_write(struct file *fp, const char __user *buf,
 	if (lenght % 8)
 		return -EINVAL;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
 	if (!access_ok(VERIFY_WRITE, buf, lenght))
+#else
+	if (!access_ok(buf, lenght))
+#endif
 		return -EFAULT;
 
 	mutex_lock(&priv->dma_tx_pool.mutex_lock);
@@ -920,8 +925,11 @@ static ssize_t hpu_chardev_read(struct file *fp, char *buf, size_t length,
 	unsigned long flags;
 	size_t read = 0;
 	struct hpu_priv *priv = fp->private_data;
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
 	if (!access_ok(VERIFY_READ, buf, length))
+#else
+	if (!access_ok(buf, length))
+#endif
 		return -EFAULT;
 
 	dev_dbg(&priv->pdev->dev, "----tot to read %d\n", length);


### PR DESCRIPTION
This PR updates the HPU driver in order to make it usable on ZynqMP.

It introduces:
- some fixes to make the driver compile against newer kernel (i.e. current EDL kernel is use on ZynqMP - and Zynq7000 as well) 
- some optimizations that make it take advantage of the ZynqMP CPUs.

This PR should also end up in some mild performance improvement on Zynq7000, but this is not the point.

Before this PR I could achieve about 100MB/s on a ZynqMP board (that is, less than Zynq7000);  after this PR I reached more than 1400MB/s on a similar ZynqMP board.

Detailed description of these changes and a performance analysis with several measurements can be found [here](https://gitlab.iit.it/edl/HpuDmaPerf)

This PR shouldn't break the userspace API (i.e. the device can still be accessed by means of `read()` syscall). The CPU load could eventually be further lowered by switching to a different API (i.e. `mmap()`); an initial idea/proposal for this has been sketched as part of the analysis in the above link, but it is not obvious that we need/want it. 